### PR TITLE
Fix python version check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ MINIMUM_PYTHON_VERSION = (3,7)
 def check_python_version():
     """Exit when the Python version is too low."""
     if sys.version_info < MINIMUM_PYTHON_VERSION:
-        sys.exit("Python {0}+ is required.".format(".".join(MINIMUM_PYTHON_VERSION)))
+        sys.exit("Python {0}+ is required.".format(".".join(map(str,MINIMUM_PYTHON_VERSION))))
 
 
 def read_package_variable(key, filename="__init__.py"):

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,13 @@ import sys
 import setuptools
 
 PACKAGE_NAME = "ldrawpy"
-MINIMUM_PYTHON_VERSION = "3.7"
+MINIMUM_PYTHON_VERSION = (3,7)
 
 
 def check_python_version():
     """Exit when the Python version is too low."""
-    if sys.version < MINIMUM_PYTHON_VERSION:
-        sys.exit("Python {0}+ is required.".format(MINIMUM_PYTHON_VERSION))
+    if sys.version_info < MINIMUM_PYTHON_VERSION:
+        sys.exit("Python {0}+ is required.".format(".".join(MINIMUM_PYTHON_VERSION)))
 
 
 def read_package_variable(key, filename="__init__.py"):


### PR DESCRIPTION
The current approach to version check doesn't work for python versions >= 3.10 since `sys.version` is a string and the string comparison checks character-by-character, so it ends up comparing `'3.1'` (eg from `'3.11'`) to `'3.7'`, which returns false.

Using the tuple comparison works for all comparisons.  The join expression maintains compatibility with the exit statement format.